### PR TITLE
Check exit code when running nimble aligner

### DIFF
--- a/nimble/__main__.py
+++ b/nimble/__main__.py
@@ -156,7 +156,7 @@ def align(param_list):
 
         print("Aligning input .bam to the reference library")
         sys.stdout.flush()
-        subprocess.call([path] + param_list)
+        p = subprocess.run([path].append(param_list), check=True)        
 
         if input_ext == ".bam":
             print("Deleting intermediate sorted .bam file")


### PR DESCRIPTION
@hextraza Does something as simple as this let us monitor the exit code? I'm not really a python programmer, but it seems like process.run() is preferred to process.call: https://csatlas.com/python-subprocess-run-exit-code/. Do we want to capture and print the raw output from the rust aligner here too? seems like maximum debugging info is important at this point.