### PR TITLE
Ignore quotes in read_csv calls

### DIFF
--- a/nimble/__main__.py
+++ b/nimble/__main__.py
@@ -221,7 +221,7 @@ def report(input, output, summarize_columns_list=None, threshold=0.05, disable_t
     # If the file has data, try to read it. Write an empty output and return if there is no data.
     if os.path.getsize(input) > 0:
         try:
-            df = pd.read_csv(input, sep='\t', low_memory=False)
+            df = pd.read_csv(input, sep='\t', low_memory=False, quoting=csv.QUOTE_NONE)
             # Use the r1 version of the cb and umi flags
             df.rename(columns={'r1_CB': 'cb', 'r1_UB': 'umi', 'nimble_features': 'features'}, inplace=True)
         except pd.errors.EmptyDataError:

--- a/nimble/__main__.py
+++ b/nimble/__main__.py
@@ -221,7 +221,7 @@ def report(input, output, summarize_columns_list=None, threshold=0.05, disable_t
     # If the file has data, try to read it. Write an empty output and return if there is no data.
     if os.path.getsize(input) > 0:
         try:
-            df = pd.read_csv(input, sep='\t', low_memory=False, quoting=csv.QUOTE_NONE)
+            df = pd.read_csv(input, sep='\t', low_memory=False, quoting=csv.QUOTE_NONE, lineterminator='\n')
             # Use the r1 version of the cb and umi flags
             df.rename(columns={'r1_CB': 'cb', 'r1_UB': 'umi', 'nimble_features': 'features'}, inplace=True)
         except pd.errors.EmptyDataError:

--- a/nimble/parse.py
+++ b/nimble/parse.py
@@ -54,7 +54,7 @@ def parse_alignment_results(input_path):
             metadata.append(line.split("\t")[1:])
 
     names = [i for i in range(0, max_line_len)]
-    return (pd.read_csv(StringIO(str_rep), header=None, names=names, quoting=csv.QUOTE_NONE), metadata)
+    return (pd.read_csv(StringIO(str_rep), header=None, names=names, quoting=csv.QUOTE_NONE, lineterminator='\n'), metadata)
 
 
 # Parse the reference.json format for the list of filters and their configurations

--- a/nimble/parse.py
+++ b/nimble/parse.py
@@ -54,7 +54,7 @@ def parse_alignment_results(input_path):
             metadata.append(line.split("\t")[1:])
 
     names = [i for i in range(0, max_line_len)]
-    return (pd.read_csv(StringIO(str_rep), header=None, names=names), metadata)
+    return (pd.read_csv(StringIO(str_rep), header=None, names=names, quoting=csv.QUOTE_NONE), metadata)
 
 
 # Parse the reference.json format for the list of filters and their configurations


### PR DESCRIPTION
The input alignment results can have single quotes within a field, such as a quality string. This PR tells read_csv to ignore quote characters, as described here:

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html